### PR TITLE
Add condition for suffix

### DIFF
--- a/src/lib/utils/index.js
+++ b/src/lib/utils/index.js
@@ -57,7 +57,7 @@ const getBotInfo = (serviceName, stage, ymlFunctionName, leoEvents, leoEventInde
   const queue = config ? config.queue : leoEvents[leoEventIndex].leo
   let botSuffix = suffix ? `-${suffix}` : botNumber > 0 ? '-' + botNumber : ''
   // If there is no botPrefix, no source queue and multiple bots: add the eventIndex to the botSuffix (bot id ultimately)
-  if (!botPrefix && !queue && leoEvents.length > 1) {
+  if (!botPrefix && !suffix && !queue && leoEvents.length > 1) {
     botSuffix = `-${leoEventIndex}${botSuffix}`
   }
   // Only add the queue to the bot name if there are multiple events and no prefix

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-leo",
-  "version": "1.4.3",
+  "version": "1.4.5",
   "description": "Serverless plugin for leo microservices",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
Don't add a number (e.g., 0, 1, etc.) to the bot id if there is a suffix defined